### PR TITLE
use md as default save extension

### DIFF
--- a/src/components/main.vue
+++ b/src/components/main.vue
@@ -302,7 +302,7 @@
           const tab = this.tabs[index]
           const filePath = tab.filePath || await dialog.showSaveDialog(currentWindow, {
             filters: [
-              {name: 'Markdown', extensions: ['markdown', 'md']}
+              {name: 'Markdown', extensions: ['md', 'markdown']}
             ]
           })
           if (filePath) {
@@ -319,7 +319,7 @@
         const tab = this.tabs[index]
         const filePath = await dialog.showSaveDialog(currentWindow, {
           filters: [
-            {name: 'Markdown', extensions: ['markdown', 'md']}
+            {name: 'Markdown', extensions: ['md', 'markdown']}
           ]
         })
         if (filePath) {


### PR DESCRIPTION
The order of extensions determine the file extension if you save without typing in the extension in the name. 
I prefer `.md` as default instead of `.markdown`.